### PR TITLE
[#15] Fixed issue with top-right Meetups button, href was not workin…

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,11 +41,11 @@ navigation:
     title: home
     weight: 1
 
-  - url: '/meetups/'
+  - url: '/meetups'
     title: meetups
     weight: 2
 
-  - url: '/posts/'
+  - url: '/posts'
     title: posts
     weight: 3
 


### PR DESCRIPTION
Fixed issue with top-right Meetups button, href was not working as expected. There has been a  problem in Jekyll 3 with trailing slashes in permalinks that could be the root of the problem. More details [here](https://github.com/jekyll/jekyll/issues/4440)