### PR TITLE
26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ruby:2.5-alpine 
+
+RUN apk add --no-cache build-base gcc bash cmake git
+
+RUN gem install jekyll
+RUN gem install bundler
+
+EXPOSE 4000
+
+WORKDIR /site
+
+ENV JEKYLL_NEW false
+
+COPY . .
+RUN gem update --system
+RUN bundle install
+
+CMD [ "bundle", "exec", "jekyll", "serve", "--force_polling", "-H", "0.0.0.0", "-P", "4000" ]

--- a/Gemfile_.lock
+++ b/Gemfile_.lock
@@ -1,0 +1,53 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    colorator (1.1.0)
+    ffi (1.9.18)
+    forwardable-extended (2.6.0)
+    jekyll (3.6.0)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.14)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (>= 1.7, < 3)
+      safe_yaml (~> 1.0)
+    jekyll-paginate-v2 (1.9.0)
+      jekyll (~> 3.0)
+    jekyll-sass-converter (1.5.0)
+      sass (~> 3.4)
+    jekyll-watch (1.5.0)
+      listen (~> 3.0, < 3.1)
+    kramdown (1.15.0)
+    liquid (4.0.0)
+    listen (3.0.6)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9.7)
+    mercenary (0.3.6)
+    pathutil (0.16.0)
+      forwardable-extended (~> 2.6)
+    public_suffix (3.0.0)
+    rb-fsevent (0.10.2)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    rouge (2.2.1)
+    safe_yaml (1.0.4)
+    sass (3.5.2)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll-paginate-v2
+
+BUNDLED WITH
+   2.0.2

--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ y abrir el browser en `http://localhost:4000`
 Si tienes Docker instalado en el sistema, accede a la raíz del proyecto y podrás optar por las siguientes opciones:
 
 - Compilar y servir en tiempo real usando el comando:
-
-````shell
-docker run -p 4000:4000 -v $(pwd):/site bretfisher/jekyll-serv
+````
+docker-compose up --build
 ````
 
 - si solo quieres compilar el proyecto puedes hacer uso de la imagen oficial de Jekyll en DockerHub:

--- a/_config.yml
+++ b/_config.yml
@@ -12,9 +12,6 @@ highlighter: 'rouge'
 plugins:
   - 'jekyll-paginate-v2'
 
-paginate: nil
-paginate_path: '/legacy/page:num/'
-
 pagination:
   enabled: true
   per_page: 10

--- a/_meetups/2017-10-26-jekyll-no-comliques-lo-que-es-sencillo.md
+++ b/_meetups/2017-10-26-jekyll-no-comliques-lo-que-es-sencillo.md
@@ -11,7 +11,7 @@ slides: http://www.setHereUrl
 code: http://www.setHereUrl
 video: http://www.youtube.com/setHereUrl
 images:
-    - src: /assets/images/meetups/2017-10-26-jekyll-no-compliques-lo-que-es-sencillo/javi.jpg
+    - src: /web/assets/images/meetups/2017-10-26-jekyll-no-compliques-lo-que-es-sencillo/javi.jpg
       width: 800
       height: 1067
       horientation: vertical

--- a/_meetups/2017-12-02-vueling-aprendiendo-vue-js.md
+++ b/_meetups/2017-12-02-vueling-aprendiendo-vue-js.md
@@ -11,32 +11,32 @@ slides: http://www.setHereUrl
 code: http://www.setHereUrl
 video: http://www.youtube.com/setHereUrl
 images:
-    - src: /assets/images/meetups/2017-12-02-vueling-aprendiendo-vue/rafa-explicando.jpg
+    - src: /web/assets/images/meetups/2017-12-02-vueling-aprendiendo-vue/rafa-explicando.jpg
       width: 600
       height: 450
       horientation: horizontal
       alt: Rafa explicando vue
-    - src: /assets/images/meetups/2017-12-02-vueling-aprendiendo-vue/rafa-explicando-dos.jpg
+    - src: /web/assets/images/meetups/2017-12-02-vueling-aprendiendo-vue/rafa-explicando-dos.jpg
       width: 600
       height: 450
       horientation: horizontal
       alt: Rafa explicando vue mas de cerca
-    - src: /assets/images/meetups/2017-12-02-vueling-aprendiendo-vue/ceramica.jpg
+    - src: /web/assets/images/meetups/2017-12-02-vueling-aprendiendo-vue/ceramica.jpg
       width: 600
       height: 450
       horientation: horizontal
       alt: Visita a taller cerámico
-    - src: /assets/images/meetups/2017-12-02-vueling-aprendiendo-vue/ceramica2.jpg
+    - src: /web/assets/images/meetups/2017-12-02-vueling-aprendiendo-vue/ceramica2.jpg
       width: 600
       height: 450
       horientation: horizontal
       alt: Otra foto de la visita al taller cerámico
-    - src: /assets/images/meetups/2017-12-02-vueling-aprendiendo-vue/mazinger.jpg
+    - src: /web/assets/images/meetups/2017-12-02-vueling-aprendiendo-vue/mazinger.jpg
       width: 600
       height: 450
       horientation: horizontal
       alt: Imagen de la cabeza de Mazinguer Z en cerámica
-    - src: /assets/images/meetups/2017-12-02-vueling-aprendiendo-vue/menu.jpg
+    - src: /web/assets/images/meetups/2017-12-02-vueling-aprendiendo-vue/menu.jpg
       width: 450
       height: 600
       horientation: vertical

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+#docker-compose up -d to run in dettach mode
+version: '3'
+
+services:
+  jekyll:
+      build: .
+      ports:
+          - 4000:4000
+      volumes:
+          - .:/site


### PR DESCRIPTION
La inclusión de la nueva paginación 'jekyll-paginate-v2' ha hecho temblar los cimientos del arranque en Docker. He creado un custom Dockerfile que incluye actualización del bundler y gemas para poder arrancarlo. De paso he arreglado la cabecera de las urls de los assets en las dos páginas que hay (añadiendo /web), que no se mostraban las imágenes.