### PR TITLE
[#11] Añadida información de asistentes

### DIFF
--- a/_includes/meetups.html
+++ b/_includes/meetups.html
@@ -16,7 +16,7 @@
                         <a class="meetup__title" href="{{ "/" | relative_url  }}{{ meetup.url | remove_first: '/' }}" >
                             {{ meetup.title }}
                         </a>
-                        <aside class="meetup__date">{{ meetup.date | date:"%b %d" }}</aside>
+                        <aside class="meetup__date">{{ meetup.date | date:"%b %d" }} | {{ meetup.attendees }} asistentes</aside>
                     </section>
                 </article>
             {% endfor %}
@@ -25,7 +25,7 @@
                 <article class="meetup">
                     <section class="meetup__info">
                         <a class="meetup__title" href="{{ meetup.url | relative_url }}">{{ meetup.title | escape }}</a>
-                        <aside class="meetup__date">{{ meetup.date | date:"%b %d" }}</aside>
+                        <aside class="meetup__date">{{ meetup.date | date:"%b %d" }} | {{ meetup.attendees }} asistentes</aside>
                     </section>
                     <section class="meetup__speaker">
                         <a class="meetup__speaker-name" href="{{ meetup.url }}" >

--- a/_layouts/meetup.html
+++ b/_layouts/meetup.html
@@ -11,7 +11,7 @@ archive: true
         <header class="meetup__header">
             <h1>{{ page.title }}</h1>
             <h2>{{ page.description }}</h2>
-            <h3>{{ page.date | date:"%B %-d, %Y" }} | {{ page.attendees }} asistentes </h3>
+            <h3>{{ page.date | date:"%B %-d, %Y" }} | {{ page.attendees }} asistentes</h3>
         </header>
         <section class="meetup__body">
             <p>{{ content }}</p>

--- a/_layouts/meetup.html
+++ b/_layouts/meetup.html
@@ -11,7 +11,7 @@ archive: true
         <header class="meetup__header">
             <h1>{{ page.title }}</h1>
             <h2>{{ page.description }}</h2>
-            <h3>{{ page.date | date:"%B %-d, %Y" }}</h3>
+            <h3>{{ page.date | date:"%B %-d, %Y" }} | {{ page.attendees }} asistentes </h3>
         </header>
         <section class="meetup__body">
             <p>{{ content }}</p>


### PR DESCRIPTION
### Descripción
Se añade el número de asistentes junto a la fecha, tanto en el `_includes/meetups.html` y en `_layouts/meetup.html`

### Adjuntos
Se muestra el resultado de los cambios
![meetups](https://user-images.githubusercontent.com/14337386/60541407-e1cfaf00-9d11-11e9-8c8a-f29905f50070.png)
![meetup](https://user-images.githubusercontent.com/14337386/60541416-e5fbcc80-9d11-11e9-94d1-57275b06b133.png)
