### PR TITLE
(#74) Añadir un GitHub action que despliegue los ficheros estáticos

### DIFF
--- a/.github/scripts/git-checks.sh
+++ b/.github/scripts/git-checks.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+function git_checks() {
+  dirty=$(git_dirty)
+  if [[ "$dirty" == "1" ]]; then
+    echo "The repository is dirty. Please clean the workspace before releasing."
+    exit 1
+  fi
+
+  tracked=$(git_num_tracked_files)
+  if [[ "$tracked" != "0" ]]; then
+    echo "The repository has ${tracked} tracked files. Please commit (or clean) them the workspace before releasing."
+    exit 1
+  fi
+
+  untracked=$(git_num_untracked_files)
+  if [[ "$untracked" != "0" ]]; then
+    echo "The repository has ${untracked} untracked files. Please clean the workspace before releasing."
+    exit 1
+  fi
+
+  echo "0"
+}
+
+function git_dirty() {
+  [[ $(git diff --shortstat 2>/dev/null | tail -n1) != "" ]] && echo "1"
+}
+
+function git_num_untracked_files() {
+  expr $(git status --porcelain 2>/dev/null | grep "^??" | wc -l | xargs)
+}
+
+function git_num_tracked_files() {
+  expr $(git status --porcelain 2>/dev/null | grep "^M" | wc -l | xargs)
+}
+
+function main() {
+  gitChecks=$(git_checks)
+
+  if [[ "$gitChecks" == "0" ]]; then
+    echo "$gitChecks"
+    exit 1
+  fi
+}
+
+main

--- a/.github/workflows/buildStatic.yml
+++ b/.github/workflows/buildStatic.yml
@@ -1,0 +1,39 @@
+name: build docs and deploy
+
+on: [push]
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - 
+      name: Checkout
+      uses: actions/checkout@v1
+    - 
+      name: Deployment
+      env:
+        JEKYLL_VERSION: "3.8"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        DOCS_BRANCH="docs_build_${GITHUB_SHA}"
+        # Create branch that will server as the source of the PR
+        git checkout -b ${DOCS_BRANCH}
+        git config --global user.name "${GITHUB_ACTOR}"
+        git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+        # Build static files
+        mkdir -p docs
+        chmod 777 -R ./docs/
+        docker run --rm --volume="$PWD:/srv/jekyll" jekyll/builder:${JEKYLL_VERSION} jekyll build
+
+        git add -A
+        git commit -m "generated: Automated docs build ${version}" --allow-empty
+        REMOTE="https://${GITHUB_ACTOR}:$GITHUB_TOKEN@github.com/${GITHUB_REPOSITORY}.git"
+        git push "${REMOTE}" HEAD:${DOCS_BRANCH}
+        
+        # Install Hub to easily do a PR
+        sudo chown root:root /
+        sudo snap install hub --classic
+        git config --global core.editor vim
+        hub pull-request -p -m "Generated: Static files" -b gdgtoledo:master -h gdgtoledo:${DOCS_BRANCH}

--- a/.github/workflows/buildStatic.yml
+++ b/.github/workflows/buildStatic.yml
@@ -1,7 +1,9 @@
 name: build docs and deploy
 
-on: [push]
-
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/buildStatic.yml
+++ b/.github/workflows/buildStatic.yml
@@ -27,6 +27,13 @@ jobs:
         chmod 777 -R ./docs/
         docker run --rm --volume="$PWD:/srv/jekyll" jekyll/builder:${JEKYLL_VERSION} jekyll build
 
+        # Check if there are git changes: dirty workspace, tracked or untracked files
+        gitChecks=$(.github/scripts/git-checks.sh)
+        if [[ "$gitChecks" == "0" ]]; then
+          echo "Aborting action as there are no modified files"
+          exit 1
+        fi
+
         git add -A
         git commit -m "generated: Automated docs build ${version}" --allow-empty
         REMOTE="https://${GITHUB_ACTOR}:$GITHUB_TOKEN@github.com/${GITHUB_REPOSITORY}.git"

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,20 +61,22 @@ docker run --rm \
 Para añadir una página con información relativa a un meetup, sigue los siguientes pasos:
 
   1. Crea una rama en la que trabajar, por ejemplo: `git checkout -b myMeetup`
-  2. Localiza la carpeta `_meetups`
-  3. Copia el fichero llamado `1900-01-01-meetup-event-name.md`, pégalo en el mismo directorio y renómbralo cambiando la fecha por la del meetup seguida del nombre del mismo, teniendo en cuenta que el nombre del fichero será usado como URL
-  4. Edita el fichero y cambia las propiedades del _front matter_ con la información del meetup (no toques `layout: meetup`)
-  5. En la sección de contenido, donde pone `Lorem ipsum...` refleja la descripción del meetup y otra información que consideres relevante
-  6. Borra la propiedad `published: false` del _front matter_ o cámbiala a `true`
-  7. Guarda los cambios y sube al repo `git add -A && git commit -m "My meetup info"`
-  8. Solicita Pull Request con la rama modificada.
+  1. Localiza la carpeta `_meetups`
+  1. Copia el fichero llamado `1900-01-01-meetup-event-name.md`, pégalo en el mismo directorio y renómbralo cambiando la fecha por la del meetup seguida del nombre del mismo, teniendo en cuenta que el nombre del fichero será usado como URL
+  1. Edita el fichero y cambia las propiedades del _front matter_ con la información del meetup (no toques `layout: meetup`)
+  1. En la sección de contenido, donde pone `Lorem ipsum...` refleja la descripción del meetup y otra información que consideres relevante
+  1. Borra la propiedad `published: false` del _front matter_ o cámbiala a `true`
+  1. Guarda los cambios y sube al repo `git add -A && git commit -m "My meetup info"`
+  1. Ejecuta el build para generar los ficheros estáticos (Ver sección `Con Docker`)
+  1. Solicita Pull Request con la rama modificada.
 
 ### Miembros
 Para añadir una página con información relativa a un miembro nuevo, sigue los siguientes pasos:
 
   1. Crea una rama en la que trabajar, por ejemplo: `git checkout -b myInfo`
-  2. Localiza la carpeta `_members`
-  3. Crea un nuevo fichero con extensión `.md` o puedes copiar uno ya existente, pero adapta el nombre del fichero para que no exista confusión.
-  4. Añade información al fichero en el formato adecuado para que Jekyll pueda leerla correctamente, puedes copiar los campos de otro fichero.
-  5. Guarda los cambios `git add -A && git commit -m "My info"`
-  6. Solicita Pull Request con la rama modificada.
+  1. Localiza la carpeta `_members`
+  1. Crea un nuevo fichero con extensión `.md` o puedes copiar uno ya existente, pero adapta el nombre del fichero para que no exista confusión.
+  1. Añade información al fichero en el formato adecuado para que Jekyll pueda leerla correctamente, puedes copiar los campos de otro fichero.
+  1. Guarda los cambios `git add -A && git commit -m "My info"`
+  1. Ejecuta el build para generar los ficheros estáticos (Ver sección `Con Docker`)
+  1. Solicita Pull Request con la rama modificada.


### PR DESCRIPTION
## ¿Qué hace esta PR?
Añade un GitHub action para generar los contenidos estáticos tras ser los fuentes modificados. Para ello el action:
- únicamente se ejecutará en la rama **master**
- creará una rama con el nombre `docs_build_SHA`, siendo SHA el ID del commit actual.
- asignará al usuario actual como author de los commits a realizar
- ejecutará el build utilizando Docker
- comprobará que hay ficheros modificados mediante un script
  - si no hay cambios, abortará el action
>De esta manera no se disparará en los forks cuando se suba una rama (la que origina la PR). Cuando se actualice la rama master de ese fork (via push), si todo va como debe, los estáticos deberían estar generados, por tanto los git-checks deberían abortar el action y enviar ninguna PR al repo central
- si hay cambios, creará un commit con el prefijo `generated:`
- instalará HUB como herramienta para enviar una PR al usuario `@gdgtoledo`.
- enviará una PR usando al propio usuario `@gdgtoledo` como sender.

Además, en el primer commit (35c4d61e9afc85176a828196a50c8133b3424203), separado, actualiza un estático que se había quedado sin actualizar de un push a master anterior.

## ¿Por qué es importante?
Permite automatizar la generación de los ficheros estáticos, así como el proceso de despliegue mediante un merge de la PR generada.

## Author's checklist
- [x] comando de build usando Docker probado en local
- [x] script de git-checks probado en local, devolviendo un 0 cuando no hay cambios en el repositorio
- [x] verificado en mi fork (https://github.com/mdelapenya/web/actions) que no se dispara de nuevo el action sobre la rama que originó la PR con cada push.

## Menciones especiales
Gracias a @avcconti por el trabajo inicial, que he utilizado como base para completar con las comprobaciones git. He hecho un stash de los commits por limpieza, pero el trabajo sucio del setup del action es todo tuyo.