### PR TITLE
Bug #64 parpadero item en lista al hacer hover

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1086,8 +1086,8 @@ h6 {
 
 .meetups__list .meetup:not(.meetup__short):hover,
 .posts__list .post:not(.post__short):hover {
-  margin-top:  20px;
-  margin-bottom: 20px;
+  padding-top:  20px;
+  padding-bottom: 20px;
 }
 
 .meetups__list .meetup__head:hover + .meetup__speaker .meetup__speaker-name,

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,20 +61,22 @@ docker run --rm \
 Para añadir una página con información relativa a un meetup, sigue los siguientes pasos:
 
   1. Crea una rama en la que trabajar, por ejemplo: `git checkout -b myMeetup`
-  2. Localiza la carpeta `_meetups`
-  3. Copia el fichero llamado `1900-01-01-meetup-event-name.md`, pégalo en el mismo directorio y renómbralo cambiando la fecha por la del meetup seguida del nombre del mismo, teniendo en cuenta que el nombre del fichero será usado como URL
-  4. Edita el fichero y cambia las propiedades del _front matter_ con la información del meetup (no toques `layout: meetup`)
-  5. En la sección de contenido, donde pone `Lorem ipsum...` refleja la descripción del meetup y otra información que consideres relevante
-  6. Borra la propiedad `published: false` del _front matter_ o cámbiala a `true`
-  7. Guarda los cambios y sube al repo `git add -A && git commit -m "My meetup info"`
-  8. Solicita Pull Request con la rama modificada.
+  1. Localiza la carpeta `_meetups`
+  1. Copia el fichero llamado `1900-01-01-meetup-event-name.md`, pégalo en el mismo directorio y renómbralo cambiando la fecha por la del meetup seguida del nombre del mismo, teniendo en cuenta que el nombre del fichero será usado como URL
+  1. Edita el fichero y cambia las propiedades del _front matter_ con la información del meetup (no toques `layout: meetup`)
+  1. En la sección de contenido, donde pone `Lorem ipsum...` refleja la descripción del meetup y otra información que consideres relevante
+  1. Borra la propiedad `published: false` del _front matter_ o cámbiala a `true`
+  1. Guarda los cambios y sube al repo `git add -A && git commit -m "My meetup info"`
+  1. Ejecuta el build para generar los ficheros estáticos (Ver sección `Con Docker`)
+  1. Solicita Pull Request con la rama modificada.
 
 ### Miembros
 Para añadir una página con información relativa a un miembro nuevo, sigue los siguientes pasos:
 
   1. Crea una rama en la que trabajar, por ejemplo: `git checkout -b myInfo`
-  2. Localiza la carpeta `_members`
-  3. Crea un nuevo fichero con extensión `.md` o puedes copiar uno ya existente, pero adapta el nombre del fichero para que no exista confusión.
-  4. Añade información al fichero en el formato adecuado para que Jekyll pueda leerla correctamente, puedes copiar los campos de otro fichero.
-  5. Guarda los cambios `git add -A && git commit -m "My info"`
-  6. Solicita Pull Request con la rama modificada.
+  1. Localiza la carpeta `_members`
+  1. Crea un nuevo fichero con extensión `.md` o puedes copiar uno ya existente, pero adapta el nombre del fichero para que no exista confusión.
+  1. Añade información al fichero en el formato adecuado para que Jekyll pueda leerla correctamente, puedes copiar los campos de otro fichero.
+  1. Guarda los cambios `git add -A && git commit -m "My info"`
+  1. Ejecuta el build para generar los ficheros estáticos (Ver sección `Con Docker`)
+  1. Solicita Pull Request con la rama modificada.

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -1086,8 +1086,8 @@ h6 {
 
 .meetups__list .meetup:not(.meetup__short):hover,
 .posts__list .post:not(.post__short):hover {
-  margin-top:  20px;
-  margin-bottom: 20px;
+  padding-top:  20px;
+  padding-bottom: 20px;
 }
 
 .meetups__list .meetup__head:hover + .meetup__speaker .meetup__speaker-name,

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -16,7 +16,7 @@ eran risas y pegatinas?&lt;/p&gt;
 
 </description>
         
-        <pubDate>Sun, 10 Nov 2013 04:18:00 -0600</pubDate>
+        <pubDate>Sun, 10 Nov 2013 11:18:00 +0100</pubDate>
         <link>https://gdgtoledo.github.io/web/posts/2013-11-10-hola-mundo/</link>
         <guid isPermaLink="true">https://gdgtoledo.github.io/web/posts/2013-11-10-hola-mundo/</guid>
       </item>


### PR DESCRIPTION
# Descripción

Con FF, Chrome y Edge se produce un parpadeo al mover el cursor del ratón entre los textos y fechas de los meetups de la página de Meetups.
El parpadeo es constante y molesto en FF y Chrome. En Edge no es apreciable y solo sucede un instante.

![71087074-96b03800-219b-11ea-96b0-2a84ed1eb4ef](https://user-images.githubusercontent.com/1202463/71927224-50943600-3195-11ea-8ce2-de7eceed2037.gif)


El parpadeo se producía porque entre item e item al hace hover se introducia un margen que hacia que, si el puntero estaba en la zona de ese margen introducido, dejaba de hacer hover. 
Al cambiar de margen a padding, el puntero nunca deja de estar dentro de la zona de hover.

# Results

![Peek 07-01-2020 21-27](https://user-images.githubusercontent.com/1202463/71927148-22aef180-3195-11ea-9c45-4d1255005e50.gif)


Close #64 