### PR TITLE
fix: Use Madrid timezone when building Jekyll static files

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -69,5 +69,6 @@ disqus_shortname: 'GDGToledo'
 url: 'https://gdgtoledo.github.io/web'
 author: 'GDG Toledo'
 authorTwitter: 'GDGToledo_es'
+timezone: Europe/Madrid
 
 permalink: '/:year/:title/'


### PR DESCRIPTION
## ¿Qué hace esta PR?
Añade el timezone de Madrid a la configuración de Jekyll: https://jekyllrb.com/docs/configuration/options/

## ¿Por qué es importante?
Para que todas las fechas sean generedas con la misma configuración del entorno. Hemos visto en el pasado que si se construye el proyecto con Docker, usa el timezone del container y no el del del desarrollador. Queremos unificar ésto y siempre sea el mismo

## Author's checks
- [x] Build en local con Docker genera las fechas en el TZ adecuado

## Issues relacionadas
- Closes #79 