### PR TITLE
fix: Polish deployment script

### DIFF
--- a/.github/workflows/buildStatic.yml
+++ b/.github/workflows/buildStatic.yml
@@ -45,4 +45,4 @@ jobs:
         sudo chown root:root /
         sudo snap install hub --classic
         git config --global core.editor vim
-        hub pull-request -p -m "Generated: Static files" -b gdgtoledo:master -h gdgtoledo:${DOCS_BRANCH}
+        hub pull-request -p -m "Generated: Static files" -b gdgtoledo:master -h ${GITHUB_ACTOR}:${DOCS_BRANCH}

--- a/.github/workflows/buildStatic.yml
+++ b/.github/workflows/buildStatic.yml
@@ -15,7 +15,7 @@ jobs:
     - 
       name: Deployment
       env:
-        JEKYLL_VERSION: "3.8"
+        JEKYLL_VERSION: ${{ 3.8 }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         DOCS_BRANCH="docs_build_${GITHUB_SHA}"

--- a/.github/workflows/buildStatic.yml
+++ b/.github/workflows/buildStatic.yml
@@ -38,8 +38,6 @@ jobs:
 
         git add -A
         git commit -m "generated: Automated docs build ${version}" --allow-empty
-        REMOTE="https://${GITHUB_ACTOR}:$GITHUB_TOKEN@github.com/${GITHUB_REPOSITORY}.git"
-        git push "${REMOTE}" HEAD:${DOCS_BRANCH}
         
         # Install Hub to easily do a PR
         sudo chown root:root /


### PR DESCRIPTION
## ¿Qué hace esta PR?
- Utiliza la [sintáxis](https://help.github.com/es/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#literals) propia de las GH Actions para los números en las variables de entorno.
- Elimina el push, puesto que hub usa el flag `-p`
- Utiliza el fork del usuario como HEAD para la rama que va a subir

## ¿Por qué es importante?
El action falla al no determinar el GITHUB_TOKEN, que debería estar generado automáticamente por el action. Puliendo el action podremos debuguear mejor lo que pasa.