### PR TITLE
fix: add git remote to hub

### DIFF
--- a/.github/workflows/buildStatic.yml
+++ b/.github/workflows/buildStatic.yml
@@ -38,6 +38,7 @@ jobs:
 
         git add -A
         git commit -m "generated: Automated docs build ${version}" --allow-empty
+        git remote add upstream "https://${GITHUB_ACTOR}:$GITHUB_TOKEN@github.com/${GITHUB_REPOSITORY}.git"
         
         # Install Hub to easily do a PR
         sudo chown root:root /


### PR DESCRIPTION
## ¿Qué hace esta PR?
Añade el remote `upstream` al repositorio, que es el remote que usa hub por defecto

## ¿Por qué es importante?
Existe una convención de remotes, y debemos utilizarla para que hub encuentre dónde enviar la PR.

Ver https://hub.github.com/hub.1.html#conventions