### PR TITLE
fix: create PR Action requires checkout@v2 action

### DIFF
--- a/.github/workflows/buildStatic.yml
+++ b/.github/workflows/buildStatic.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - 
       name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - 
       name: Build Static Files
       env:


### PR DESCRIPTION
## ¿Qué hace esta PR?
Utiliza la versión requerida por el action de create-pull-request

## ¿Por qué es importante?
RTFM es siempre importante