### PR TITLE
fix: let action do its job

### DIFF
--- a/.github/workflows/buildStatic.yml
+++ b/.github/workflows/buildStatic.yml
@@ -20,7 +20,6 @@ jobs:
       run: |
         # Build static files
         mkdir -p docs
-        chmod 777 -R ./docs/
         docker run --rm --volume="$PWD:/srv/jekyll" jekyll/builder:${JEKYLL_VERSION} jekyll build
 
         # Check if there are git changes: dirty workspace, tracked or untracked files

--- a/.github/workflows/buildStatic.yml
+++ b/.github/workflows/buildStatic.yml
@@ -38,10 +38,10 @@ jobs:
         branch: docs_build_${GITHUB_SHA}
         committer: GDG Toledo <${GITHUB_ACTOR}@users.noreply.github.com>
         author: GDG Toledo <${GITHUB_ACTOR}@users.noreply.github.com>
-        title: 'generated: Automated docs build'
+        title: 'generated: Build static files'
         body: |
             ## ¿Qué hace esa PR?
-            - Ficheros estáticos auto-generados [create-pull-request][1]
+            - Ficheros estáticos auto-generados con [create-pull-request][1]
 
             ## ¿Por qué es importante?
             Los ficheros estáticos deben generarse con cada cambio, y con esta PR aseguramos que a nadie se le olvida.

--- a/.github/workflows/buildStatic.yml
+++ b/.github/workflows/buildStatic.yml
@@ -18,12 +18,6 @@ jobs:
         JEKYLL_VERSION: ${{ 3.8 }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        DOCS_BRANCH="docs_build_${GITHUB_SHA}"
-        # Create branch that will server as the source of the PR
-        git checkout -b ${DOCS_BRANCH}
-        git config --global user.name "${GITHUB_ACTOR}"
-        git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-
         # Build static files
         mkdir -p docs
         chmod 777 -R ./docs/
@@ -35,18 +29,13 @@ jobs:
           echo "Aborting action as there are no modified files"
           exit 1
         fi
-
-        git add -A
-        git commit -m "generated: Automated docs build ${version}" --allow-empty
-        git remote add upstream "https://${GITHUB_ACTOR}:$GITHUB_TOKEN@github.com/${GITHUB_REPOSITORY}.git"
-
     -
       name: Create Pull Request
       uses: peter-evans/create-pull-request@v2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: "generated: Automated docs build"
-        branch: master
+        branch: docs_build_${GITHUB_SHA}
         committer: GDG Toledo <${GITHUB_ACTOR}@users.noreply.github.com>
         author: GDG Toledo <${GITHUB_ACTOR}@users.noreply.github.com>
         title: 'generated: Automated docs build'


### PR DESCRIPTION
## ¿Qué hace esta PR?
Esta PR hace un par de cosas:
- no cambia los permisos del directorio docs a 777, que causaba en primera instancia que muchos ficheros fueran re-actualizados (esto habría que verlo más detenidamente, porque a lo mejor nos interesa para unificar permisos en los repos locales)
- ajusta algunos textos en la descripción de la PR a enviar
- elimina el código de generación del commit que hacíamos a mano, ya que es el action el que se encarga de todo.

## ¿Por qué es importante?
Dejemos que cada step haga sus cosas por separado