### PR TITLE
fix: fix permissions issue

### DIFF
--- a/.github/workflows/buildStatic.yml
+++ b/.github/workflows/buildStatic.yml
@@ -20,6 +20,7 @@ jobs:
       run: |
         # Build static files
         mkdir -p docs
+        chmod 777 -R ./docs/
         docker run --rm --volume="$PWD:/srv/jekyll" jekyll/builder:${JEKYLL_VERSION} jekyll build
 
         # Check if there are git changes: dirty workspace, tracked or untracked files


### PR DESCRIPTION
## ¿Qué hace esta PR?
Vuelve a poner los permisos 777 en el directorio docs

## ¿Por qué es importante?
Al parecer no hay permisos de escritura dentro del action para el container que lanzamos para hacer el build de Jekyll