### PR TITLE
feat: Saltarse la creación de la PR si no hay cambios tras el build de Jekyll

### DIFF
--- a/.github/workflows/buildStatic.yml
+++ b/.github/workflows/buildStatic.yml
@@ -36,8 +36,6 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: "generated: Automated docs build"
         branch: docs_build_${GITHUB_SHA}
-        committer: GDG Toledo <${GITHUB_ACTOR}@users.noreply.github.com>
-        author: GDG Toledo <${GITHUB_ACTOR}@users.noreply.github.com>
         title: 'generated: Build static files'
         body: |
             ## ¿Qué hace esa PR?

--- a/.github/workflows/buildStatic.yml
+++ b/.github/workflows/buildStatic.yml
@@ -26,16 +26,17 @@ jobs:
         # Check if there are git changes: dirty workspace, tracked or untracked files
         gitChecks=$(.github/scripts/git-checks.sh)
         if [[ "$gitChecks" == "0" ]]; then
-          echo "Aborting action as there are no modified files"
-          exit 1
+          echo "::warning ::Skipping PR creation as there are no modified files"
+          echo "::set-env name=SKIP_CREATE_PR::true"
         fi
     -
       name: Create Pull Request
       uses: peter-evans/create-pull-request@v2
+      if: ${{ env.SKIP_CREATE_PR != "true" }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: "generated: Automated docs build"
-        branch: docs_build_${GITHUB_SHA}
+        branch: docs_build_${{ env.GITHUB_SHA }}"
         title: 'generated: Build static files'
         body: |
             ## ¿Qué hace esa PR?


### PR DESCRIPTION
## ¿Qué hace esta PR?
Crea una variable de entorno si no hay cambios en GIT para luego comprobar en el step de creación de PR si existe y es `true`. Si no es así, ejecuta la PR porque sí hay cambios tras el build.

Además cambia el formato del nombre de rama para utilizar una expresión, ya que se generaba una rama errónea sin interpolar el nombre de la variable.

## ¿Por qué es importante?
Si la PR no tiene cambios tras el build (p.e. tras mergear una PR autogenerada se dispara el action de nuevo, y cómo viene de un conjunto de ficheros modificados ya generados el build no genera nada), el action falla marcando el commit como fallido, que es incorrecto. Por eso queremos saltar la creación de PR en esos casos, y que todos los steps sean OK (pasen en verde)

## Related issues
Closes #88