### PR TITLE
fix: no usar el formato de expresión en el IF

### DIFF
--- a/.github/workflows/buildStatic.yml
+++ b/.github/workflows/buildStatic.yml
@@ -32,7 +32,7 @@ jobs:
     -
       name: Create Pull Request
       uses: peter-evans/create-pull-request@v2
-      if: ${{ env.SKIP_CREATE_PR != "true" }}
+      if: env.SKIP_CREATE_PR != "true"
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: "generated: Automated docs build"


### PR DESCRIPTION
## ¿Qué hace esta PR?
Elimina el formato de expresión del IF

https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
>Expressions in an if conditional do not require the ${{ }} syntax. For more information, see "Contexts and expression syntax for GitHub Actions."

## ¿Por qué es importante?
El action falla porque el formato del fichero es incorrecto