### PR TITLE
fix: set proper error levels to avoid GH action shell to exit

### DIFF
--- a/.github/scripts/git-checks.sh
+++ b/.github/scripts/git-checks.sh
@@ -4,22 +4,22 @@ function git_checks() {
   dirty=$(git_dirty)
   if [[ "$dirty" == "1" ]]; then
     echo "The repository is dirty. Please clean the workspace before releasing."
-    exit 1
+    return 1
   fi
 
   tracked=$(git_num_tracked_files)
   if [[ "$tracked" != "0" ]]; then
     echo "The repository has ${tracked} tracked files. Please commit (or clean) them the workspace before releasing."
-    exit 1
+    return 1
   fi
 
   untracked=$(git_num_untracked_files)
   if [[ "$untracked" != "0" ]]; then
     echo "The repository has ${untracked} untracked files. Please clean the workspace before releasing."
-    exit 1
+    return 1
   fi
 
-  echo "0"
+  return 0
 }
 
 function git_dirty() {
@@ -36,11 +36,10 @@ function git_num_tracked_files() {
 
 function main() {
   gitChecks=$(git_checks)
+  returnValue=$?
+  echo "$gitChecks"
 
-  if [[ "$gitChecks" == "0" ]]; then
-    echo "$gitChecks"
-    exit 1
-  fi
+  return $returnValue
 }
 
 main

--- a/.github/workflows/buildStatic.yml
+++ b/.github/workflows/buildStatic.yml
@@ -25,7 +25,8 @@ jobs:
 
         # Check if there are git changes: dirty workspace, tracked or untracked files
         gitChecks=$(.github/scripts/git-checks.sh)
-        if [[ "$gitChecks" == "0" ]]; then
+        # Check error level
+        if [[ "$?" == "0" ]]; then
           echo "::warning ::Skipping PR creation as there are no modified files"
           echo "::set-env name=SKIP_CREATE_PR::true"
         fi


### PR DESCRIPTION
## ¿Qué hace esta PR?
Modifica los error levels del shell script que comprueba el estado del repositorio Git, de modo que no fuerza la terminación de la terminal que lo lanzó, en este caso el action. Ahora estas funciones hacen un `return` en lugar de un `exit`, tal y como se explica [aquí](https://unix.stackexchange.com/a/138736)

## ¿Por qué es importante?
No queremos abortar la terminal, y por tanto el action, puesto que marca el commit como fallido cuando realmente los cambios que van en esa PR no afectan, puesto que se ha determinado no lanzar una PR.