### PR TITLE
chore: Añadir un comando de run al build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ RUN apk add --no-cache build-base gcc bash cmake git
 RUN gem install bundler
 RUN gem update --system
 
-EXPOSE 4000
-
 WORKDIR /site
 
 ENV JEKYLL_NEW false
@@ -14,4 +12,4 @@ ENV JEKYLL_NEW false
 COPY . .
 RUN bundle install
 
-CMD [ "bundle", "exec", "jekyll", "serve", "--force_polling", "-H", "0.0.0.0", "-P", "4000" ]
+CMD [ "bundle", "exec", "jekyll", "serve", "--force_polling", "-H", "0.0.0.0" ]

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,8 @@ build:
 	mkdir -p $$PWD/docs/
 	chmod -R 777 $$PWD/docs/
 	docker run --rm --volume="$$PWD:/srv/jekyll" jekyll/builder:$(JEKYLL_VERSION) jekyll build
+
+.PHONY: run
+run:
+	@echo "Running Static files"
+	docker-compose up --build

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ y abrir el browser en `http://localhost:4000`
 Si tienes Docker instalado en el sistema, accede a la raíz del proyecto y podrás optar por las siguientes opciones:
 
 - Compilar y servir en tiempo real usando el comando:
-````
-docker-compose up --build
+````shell
+make run
 ````
 
 - si solo quieres compilar el proyecto puedes hacer uso de la imagen oficial de Jekyll en DockerHub:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Si tienes Docker instalado en el sistema, accede a la ra√≠z del proyecto y podr√
 make run
 ````
 
+y abrir el browser en `http://localhost:4000`
+
 - si solo quieres compilar el proyecto puedes hacer uso de la imagen oficial de Jekyll en DockerHub:
 
 ````shell

--- a/_config.yml
+++ b/_config.yml
@@ -73,3 +73,6 @@ authorTwitter: 'GDGToledo_es'
 timezone: Europe/Madrid
 
 permalink: '/:year/:title/'
+
+# deployment
+port: 5000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,6 @@ services:
   jekyll:
       build: .
       ports:
-          - 4000:4000
+          - 4000:5000
       volumes:
           - .:/site


### PR DESCRIPTION
## ¿Qué hace esta PR?
Añade el comando `run` al Makefile, de modo que sea más fácil ejecutar la aplicación de manera local.

Además, añade la sección `deployment` a la configuración de Jekyll para que sea posible definir el puerto a utilizar. Esto lo hacemos así para seguir el estándar. Por tanto se elimina el puerto marcado a fuego del Dockerfile

## ¿Por qué es importante?
Mejora la experiencia local de desarrollo: `make run` Vs `docker-compose up --build`, así como respeta la configuración estándar de Jekyll, pudiendo definir el puerto que queramos (no obstante, con Compose usaremos el puerto 4000) bindeado al puerto que se indique.

## Issues relacionadas
- Closes #100