### PR TITLE
Mejorar la UX de los posts

### DIFF
--- a/_includes/meetups.html
+++ b/_includes/meetups.html
@@ -46,7 +46,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="{{ meetup.url }}" >
+                        <a class="meetup__speaker-name" href="{{ meetup.url | relative_url }}" >
                             {{ meetup.speaker.name }}
                         </a>
                     </section>

--- a/_includes/posts.html
+++ b/_includes/posts.html
@@ -28,7 +28,14 @@
                     <div class="post__head">
                         <section class="post__info">
                             <a class="post__title" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
-                            <aside class="post__date">{{ post.date | date:"%b %d, %Y" }}</aside>
+                            <aside class="post__details">
+                                <span class="post__date">
+                                    {{ post.date | date:"%b %d, %Y" }}
+                                </span>
+                                <span class="post__author">
+                                    Por {{ post.author.name }}
+                                </span>
+                            </aside>
                         </section>
                     </div>
                     <section class="post__description">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -11,8 +11,10 @@ archive: true
         <header class="post__header">
             <h1 class="post__title">{{ page.title }}</h1>
             <h2 class="post__description">> {{ page.description }}</h2>
-            <h3 class="post__date">{{ page.date | date:"%B %-d, %Y" }}</h3>
-            <h4 class="post__author">Por {{ page.author.name }} (<a class="twitter" href="https://twitter.com/{{ page.author.twitter }}"><span class="icon-twitter"> @{{ page.author.twitter }}</span></a>)</h4>
+            <h3 class="post__details">
+                <span class="post__date">{{ page.date | date:"%B %-d, %Y" }}</span>
+                <span class="post__author">Por {{ page.author.name }} (<a class="twitter" href="https://twitter.com/{{ page.author.twitter }}"><span class="icon-twitter"> @{{ page.author.twitter }}</span></a>)</span>
+            </h3>
         </header>
         <section id="post-body" class="post__body">
             {{content}}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1102,7 +1102,7 @@ h6 {
 }
 
 .meetups__list .meetup__info:hover .meetup__details,
-.posts__list .post__info:hover .post__date {
+.posts__list .post__info:hover .post__details {
   text-decoration: none;
   color: var(--color-black);
 }
@@ -1116,6 +1116,17 @@ h6 {
   box-shadow: inset 0 -7px 0 var(--text-color-primary);
 }
 
+.posts__list .post__info .post__date,
+.posts__list .post__info:hover .post__author {
+  display: block;
+}
+
+.posts__list .post__info .post__author,
+.posts__list .post__info:hover .post__date {
+  display: none;
+}
+
+.posts__list .post__info .post__details,
 .meetups__list .meetup__info .meetup__details {
   display: flex;
   flex-direction: row;
@@ -1148,7 +1159,7 @@ h6 {
 }
 
 .meetups__list .meetup__details,
-.posts__list .post__date {
+.posts__list .post__details {
   padding: 10px 0 0 0;
   font-family: var(--font-family-rubik);
   font-weight: var(--text-weight-medium);

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -740,6 +740,7 @@ h6 {
   font-style: normal;
 }
 
+.post__header .post__details,
 .meetup__header .meetup__details {
   display: flex;
   flex-direction: column;

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -740,6 +740,7 @@ h6 {
   font-style: normal;
 }
 
+.post__header .post__details,
 .meetup__header .meetup__details {
   display: flex;
   flex-direction: column;
@@ -1102,7 +1103,7 @@ h6 {
 }
 
 .meetups__list .meetup__info:hover .meetup__details,
-.posts__list .post__info:hover .post__date {
+.posts__list .post__info:hover .post__details {
   text-decoration: none;
   color: var(--color-black);
 }
@@ -1116,6 +1117,17 @@ h6 {
   box-shadow: inset 0 -7px 0 var(--text-color-primary);
 }
 
+.posts__list .post__info .post__date,
+.posts__list .post__info:hover .post__author {
+  display: block;
+}
+
+.posts__list .post__info .post__author,
+.posts__list .post__info:hover .post__date {
+  display: none;
+}
+
+.posts__list .post__info .post__details,
 .meetups__list .meetup__info .meetup__details {
   display: flex;
   flex-direction: row;
@@ -1148,7 +1160,7 @@ h6 {
 }
 
 .meetups__list .meetup__details,
-.posts__list .post__date {
+.posts__list .post__details {
   padding: 10px 0 0 0;
   font-family: var(--font-family-rubik);
   font-weight: var(--text-weight-medium);

--- a/docs/credits/index.html
+++ b/docs/credits/index.html
@@ -57,8 +57,10 @@
         <header class="post__header">
             <h1 class="post__title">Créditos</h1>
             <h2 class="post__description">> </h2>
-            <h3 class="post__date"></h3>
-            <h4 class="post__author">Por GDG Toledo (<a class="twitter" href="https://twitter.com/gdgtoledo_es"><span class="icon-twitter"> @gdgtoledo_es</span></a>)</h4>
+            <h3 class="post__details">
+                <span class="post__date"></span>
+                <span class="post__author">Por GDG Toledo (<a class="twitter" href="https://twitter.com/gdgtoledo_es"><span class="icon-twitter"> @gdgtoledo_es</span></a>)</span>
+            </h3>
         </header>
         <section id="post-body" class="post__body">
             <h2 id="iconos">Iconos</h2>

--- a/docs/meetups/2/index.html
+++ b/docs/meetups/2/index.html
@@ -79,7 +79,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="/meetups/2019-09-12-mi-aplicacion-falla-y-no-se-por-que-por-donde-empiezo/" >
+                        <a class="meetup__speaker-name" href="/web/meetups/2019-09-12-mi-aplicacion-falla-y-no-se-por-que-por-donde-empiezo/" >
                             Manuel de la Peña
                         </a>
                     </section>
@@ -100,7 +100,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="/meetups/2019-06-08-cloud-study-jam-machine-learning-apis/" >
+                        <a class="meetup__speaker-name" href="/web/meetups/2019-06-08-cloud-study-jam-machine-learning-apis/" >
                             Laura Morillo
                         </a>
                     </section>
@@ -121,7 +121,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="/meetups/2019-04-25-groogleando-voy/" >
+                        <a class="meetup__speaker-name" href="/web/meetups/2019-04-25-groogleando-voy/" >
                             Jorge Aguilera
                         </a>
                     </section>
@@ -142,7 +142,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="/meetups/2019-03-28-clean-architectures/" >
+                        <a class="meetup__speaker-name" href="/web/meetups/2019-03-28-clean-architectures/" >
                             Álvaro García Loaisa
                         </a>
                     </section>
@@ -163,7 +163,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="/meetups/2019-02-28-necesito-una-cli-la-escribo-en-node-o-en-go/" >
+                        <a class="meetup__speaker-name" href="/web/meetups/2019-02-28-necesito-una-cli-la-escribo-en-node-o-en-go/" >
                             Javier de Ancos y Manuel de la Peña
                         </a>
                     </section>
@@ -184,7 +184,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="/meetups/2019-02-28-dream-qa/" >
+                        <a class="meetup__speaker-name" href="/web/meetups/2019-02-28-dream-qa/" >
                             Manuel de la Peña
                         </a>
                     </section>
@@ -205,7 +205,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="/meetups/2018-11-28-como-crear-una-aplicacion-de-voz/" >
+                        <a class="meetup__speaker-name" href="/web/meetups/2018-11-28-como-crear-una-aplicacion-de-voz/" >
                             Nieves Ábalos y Carlos Muñoz-Romero
                         </a>
                     </section>
@@ -226,7 +226,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="/meetups/2018-11-22-dockeriza-tu-aplicacion-php/" >
+                        <a class="meetup__speaker-name" href="/web/meetups/2018-11-22-dockeriza-tu-aplicacion-php/" >
                             Andres Velasco
                         </a>
                     </section>
@@ -247,7 +247,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="/meetups/2018-11-10-women-in-tech-de-cero-a-front-pasando-por-adalaba/" >
+                        <a class="meetup__speaker-name" href="/web/meetups/2018-11-10-women-in-tech-de-cero-a-front-pasando-por-adalaba/" >
                             Aylen Ortiz-Jaureguizar, Ester González, Laura Domingo y Laura Moñino
                         </a>
                     </section>
@@ -268,7 +268,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="/meetups/2018-10-04-21-dias-haciendo-tests-lo-que-he-aprendido/" >
+                        <a class="meetup__speaker-name" href="/web/meetups/2018-10-04-21-dias-haciendo-tests-lo-que-he-aprendido/" >
                             Manu García
                         </a>
                     </section>

--- a/docs/meetups/index.html
+++ b/docs/meetups/index.html
@@ -79,7 +79,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="/meetups/2018-07-05-hagamos-extremme-programming/" >
+                        <a class="meetup__speaker-name" href="/web/meetups/2018-07-05-hagamos-extremme-programming/" >
                             José Julián Ariza
                         </a>
                     </section>
@@ -100,7 +100,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="/meetups/2018-06-16-primer-hackday-gdg-toledo/" >
+                        <a class="meetup__speaker-name" href="/web/meetups/2018-06-16-primer-hackday-gdg-toledo/" >
                             Manuel de la Peña
                         </a>
                     </section>
@@ -121,7 +121,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="/meetups/2018-05-08-i-o-extended-2018-toledo/" >
+                        <a class="meetup__speaker-name" href="/web/meetups/2018-05-08-i-o-extended-2018-toledo/" >
                             GDG Toledo
                         </a>
                     </section>
@@ -142,7 +142,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="/meetups/2018-03-27-automate-your-build/" >
+                        <a class="meetup__speaker-name" href="/web/meetups/2018-03-27-automate-your-build/" >
                             Manuel de la Peña
                         </a>
                     </section>
@@ -163,7 +163,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="/meetups/2018-02-28-ven-a-conocer-el-big-data/" >
+                        <a class="meetup__speaker-name" href="/web/meetups/2018-02-28-ven-a-conocer-el-big-data/" >
                             Eun Young Cho Eoh
                         </a>
                     </section>
@@ -184,7 +184,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="/meetups/2018-02-05-blockchain-ethic-hub-toledo/" >
+                        <a class="meetup__speaker-name" href="/web/meetups/2018-02-05-blockchain-ethic-hub-toledo/" >
                             Jori Armbruster, Gabriela Chang e Íñigo Molero
                         </a>
                     </section>
@@ -205,7 +205,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="/meetups/2018-01-11-clean-code/" >
+                        <a class="meetup__speaker-name" href="/web/meetups/2018-01-11-clean-code/" >
                             Álvaro García Loaisa
                         </a>
                     </section>
@@ -226,7 +226,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="/meetups/2017-10-26-jekyll-no-comliques-lo-que-es-sencillo/" >
+                        <a class="meetup__speaker-name" href="/web/meetups/2017-10-26-jekyll-no-comliques-lo-que-es-sencillo/" >
                             Javier López de Ancos
                         </a>
                     </section>
@@ -247,7 +247,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="/meetups/2017-12-02-vueling-aprendiendo-vue-js/" >
+                        <a class="meetup__speaker-name" href="/web/meetups/2017-12-02-vueling-aprendiendo-vue-js/" >
                             Rafael Garcia
                         </a>
                     </section>
@@ -268,7 +268,7 @@
                         </section>
                     </div>
                     <section class="meetup__speaker">
-                        <a class="meetup__speaker-name" href="/meetups/2017-06-22-stop-starting-start-finishing-una-introduccion-a-kanban/" >
+                        <a class="meetup__speaker-name" href="/web/meetups/2017-06-22-stop-starting-start-finishing-una-introduccion-a-kanban/" >
                             Manuel de la Peña y Antonio Crespo
                         </a>
                     </section>

--- a/docs/posts/2013-11-10-hola-mundo/index.html
+++ b/docs/posts/2013-11-10-hola-mundo/index.html
@@ -57,8 +57,10 @@
         <header class="post__header">
             <h1 class="post__title">Hola Mundo</h1>
             <h2 class="post__description">> Bienvenidos al blog de GDG Toledo</h2>
-            <h3 class="post__date">November 10, 2013</h3>
-            <h4 class="post__author">Por GDG Toledo (<a class="twitter" href="https://twitter.com/gdgtoledo_es"><span class="icon-twitter"> @gdgtoledo_es</span></a>)</h4>
+            <h3 class="post__details">
+                <span class="post__date">November 10, 2013</span>
+                <span class="post__author">Por GDG Toledo (<a class="twitter" href="https://twitter.com/gdgtoledo_es"><span class="icon-twitter"> @gdgtoledo_es</span></a>)</span>
+            </h3>
         </header>
         <section id="post-body" class="post__body">
             <h1 id="títulos-y-párrafos">Títulos y párrafos</h1>

--- a/docs/posts/2020-04-16-cansino/index.html
+++ b/docs/posts/2020-04-16-cansino/index.html
@@ -57,8 +57,10 @@
         <header class="post__header">
             <h1 class="post__title">Cansino</h1>
             <h2 class="post__description">> Cansineando a los políticos</h2>
-            <h3 class="post__date">March 16, 2020</h3>
-            <h4 class="post__author">Por Manuel de la Peña (<a class="twitter" href="https://twitter.com/mdelapenya"><span class="icon-twitter"> @mdelapenya</span></a>)</h4>
+            <h3 class="post__details">
+                <span class="post__date">March 16, 2020</span>
+                <span class="post__author">Por Manuel de la Peña (<a class="twitter" href="https://twitter.com/mdelapenya"><span class="icon-twitter"> @mdelapenya</span></a>)</span>
+            </h3>
         </header>
         <section id="post-body" class="post__body">
             <p>A veces los políticos y las políticas de turno hablan mucho sobre lo que ellos dicen que es importante para la ciudadanía, y a su vez, muchas otras veces encontramos que no hacen lo que dicen.</p>

--- a/docs/posts/index.html
+++ b/docs/posts/index.html
@@ -68,7 +68,14 @@
                     <div class="post__head">
                         <section class="post__info">
                             <a class="post__title" href="/web/posts/2020-04-16-cansino/">Cansino</a>
-                            <aside class="post__date">Mar 16, 2020</aside>
+                            <aside class="post__details">
+                                <span class="post__date">
+                                    Mar 16, 2020
+                                </span>
+                                <span class="post__author">
+                                    Por Manuel de la Peña
+                                </span>
+                            </aside>
                         </section>
                     </div>
                     <section class="post__description">
@@ -82,7 +89,14 @@
                     <div class="post__head">
                         <section class="post__info">
                             <a class="post__title" href="/web/posts/2013-11-10-hola-mundo/">Hola Mundo</a>
-                            <aside class="post__date">Nov 10, 2013</aside>
+                            <aside class="post__details">
+                                <span class="post__date">
+                                    Nov 10, 2013
+                                </span>
+                                <span class="post__author">
+                                    Por GDG Toledo
+                                </span>
+                            </aside>
                         </section>
                     </div>
                     <section class="post__description">


### PR DESCRIPTION
## ¿Qué hace esta PR?
Utiliza la misma UX en los posts que en los meetups, esto es:

- mismo bloque de detalles al ver un post
- mostrar de manera selectiva (onHover) la fecha del post o su author en la lista posts

Además se aprovecha para normalizar la URL al meetup si se clica en el speaker, que originaba un 404.

## ¿Por qué es importante?
KICS: Keep It Consistent Stupid

## Issues relacionadas
- Closes #109
- Closes #110