### PR TITLE
Añadir margenes para hacer mas legibles los post

### DIFF
--- a/_layouts/meetups.html
+++ b/_layouts/meetups.html
@@ -6,5 +6,6 @@ layout: default
 
 <div class="page-container">
     {% include meetups.html %}
-    {% include footer.html %}
 </div>
+
+{% include footer.html %}

--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -6,5 +6,6 @@ layout: default
 
 <div class="page-container">
     {% include posts.html %}
-    {% include footer.html %}
 </div>
+
+{% include footer.html %}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -589,10 +589,15 @@ h6 {
   padding: 11vh 6vw 6vh 6vw;
 }
 
+@media all and (min-width: 850px) {
+  .page-container {
+    padding: 11vh 25vw 6vh 25vw;
+  }
+}
+
 .page-container section:last-child ul {
   margin-bottom: 0;
 }
-
 
 .app-container {
   width: 100%;

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -589,10 +589,15 @@ h6 {
   padding: 11vh 6vw 6vh 6vw;
 }
 
+@media all and (min-width: 850px) {
+  .page-container {
+    padding: 11vh 25vw 6vh 25vw;
+  }
+}
+
 .page-container section:last-child ul {
   margin-bottom: 0;
 }
-
 
 .app-container {
   width: 100%;

--- a/docs/meetups/2/index.html
+++ b/docs/meetups/2/index.html
@@ -313,10 +313,11 @@
 </section>
 
 
-    <footer class="footer">
+</div>
+
+<footer class="footer">
     <p class="small">Hecho con 🤘  por GDG Toledo</p>
 </footer>
-</div>
     </main>
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>

--- a/docs/meetups/3/index.html
+++ b/docs/meetups/3/index.html
@@ -162,10 +162,11 @@
 </section>
 
 
-    <footer class="footer">
+</div>
+
+<footer class="footer">
     <p class="small">Hecho con 🤘  por GDG Toledo</p>
 </footer>
-</div>
     </main>
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>

--- a/docs/meetups/index.html
+++ b/docs/meetups/index.html
@@ -309,10 +309,11 @@
 </section>
 
 
-    <footer class="footer">
+</div>
+
+<footer class="footer">
     <p class="small">Hecho con 🤘  por GDG Toledo</p>
 </footer>
-</div>
     </main>
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>

--- a/docs/posts/index.html
+++ b/docs/posts/index.html
@@ -94,10 +94,11 @@
     
 
 </section>
-    <footer class="footer">
+</div>
+
+<footer class="footer">
     <p class="small">Hecho con 🤘  por GDG Toledo</p>
 </footer>
-</div>
     </main>
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>


### PR DESCRIPTION
# Issue
Close #127 

# Descripción
Añadir margenes para logra más legibilidad en el contenedor de página.
Los márgenes solo los agregaremos pa partir que la pantalla sea mayor que `800px` para que en dispositivos tableta y móviles estos márgenes seán mucho más pequeños para aprovechar bien el ancho de la pantalla en estos dispositivos.
![Screenshot_20200328_105432](https://user-images.githubusercontent.com/1202463/77822805-58a9a500-70f6-11ea-86cf-cb79c32a156d.png)


# Cambios

## Home
![home](https://user-images.githubusercontent.com/1202463/77822814-62cba380-70f6-11ea-8f23-bebbf9ece21d.gif)

## Meetups
![meetups](https://user-images.githubusercontent.com/1202463/77822820-6bbc7500-70f6-11ea-9d70-a240d287ef60.gif)

## Meetup
![meetup](https://user-images.githubusercontent.com/1202463/77822826-75de7380-70f6-11ea-91cd-a0aaa88428c6.gif)

## Posts
![posts](https://user-images.githubusercontent.com/1202463/77822832-81319f00-70f6-11ea-8517-3a60a14ab47f.gif)

## Post
![post](https://user-images.githubusercontent.com/1202463/77822835-8989da00-70f6-11ea-963b-497d380438f5.gif)

## Comportamiento Tableta/Desktop  
![responsive](https://user-images.githubusercontent.com/1202463/77822848-a9210280-70f6-11ea-8017-619b7cac1119.gif)


